### PR TITLE
Fix color format type "rgba" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Property | Default | Meaning
 ---|---|---
 `colormap` | `'jet'` | Color map name from the image above or a custom color scale — a sequence of `{index, rgb}` objects, where index is `0..1` number and `rgb` is a length 3/4 array with values for the color stop.
 `nshades` | `72` | Number of colors in returned array, the minimum number depends on `colormap`.
-`format` | `'hex'` | `'hex'` for `#aabbcc`, `'rgbaString'` for `rgba(255, 255, 255, 1)`, `'rba'` for `[255, 255, 255, 1]`, `'float'` for `[1, 1, 1, 1]`.
+`format` | `'hex'` | `'hex'` for `#aabbcc`, `'rgbaString'` for `rgba(255, 255, 255, 1)`, `'rgba'` for `[255, 255, 255, 1]`, `'float'` for `[1, 1, 1, 1]`.
 `alpha` | `1` | Alpha range, can be an array with alpha values or just 2 values for start/end colors. |
 
 


### PR DESCRIPTION
The RGBA format type is probably meant to be `"rgba"` instead of `"rga"`. The error in the README doesn't affect the usage of the library though because anything other than `"hex"`, `"rgbaString"`, and `"float"` will return the RGBA 4-tuple.